### PR TITLE
Refactor multiModuleRotator error handling to use string array

### DIFF
--- a/src/Presentation/View/templates/pages/display.twig
+++ b/src/Presentation/View/templates/pages/display.twig
@@ -146,11 +146,11 @@
                         <p class="text-center text-gray-500 max-sm:text-xs max-md:text-sm max-lg:text-base max-xl:text-lg max-2xl:text-xl text-2xl">Brak danych do wyświetlenia</p>
                     </div>
                 </template>
-                <template x-if="error">
-                    <template x-for="(errors, index) in error" :key="`error-${index}-${error}`">
+                <template x-if="error.length">
+                    <template x-for="(message, index) in error" :key="`error-${index}-${message}`">
                         <div class="bg-red-100 mt-2 mx-2 max-sm:hidden max-md:text-xs max-lg:text-sm text-base border border-red-500 rounded-lg flex items-center space-x-2">
                             <i class="fa-solid fa-triangle-exclamation text-red-500 max-sm:p-1 max-md:p-1.5 p-2" aria-hidden="true"></i>
-                            <p class="text-red-500 max-md:text-[10px] max-lg:text-xs max-xl:text-sm text-base font-medium" x-text="errors"></p>
+                            <p class="text-red-500 max-md:text-[10px] max-lg:text-xs max-xl:text-sm text-base font-medium" x-text="message"></p>
                         </div>
                     </template>
                 </template>
@@ -389,6 +389,9 @@
             countdownData: null,
             countdownIntervalId: null,
             message: '',
+            pushError(msg) {
+                if (!this.error.includes(msg)) this.error.push(msg);
+            },
 
             endpoints: [
                 { name: 'countdown', url: '/display/countdown' },
@@ -411,16 +414,16 @@
                                 method: 'GET',
                                 headers: { 'Content-Type': 'application/json' },
                             });
-                            if (!res.ok) this.error = (`Błąd HTTP ${res.status} modułu ${name}`);
+                            if (!res.ok) this.pushError(`Błąd HTTP ${res.status} modułu ${name}`);
                             let json;
                             try {
                                 json = await res.json();
                             } catch (e) {
-                                this.error = (`Niepoprawny JSON ${this.names[name]}`);
+                                this.pushError(`Niepoprawny JSON ${this.names[name]}`);
                             }
 
-                            if (!json && !this.error.includes(`Brak danych w module ${name}`)) {
-                                this.error.push(`Brak danych w module ${name}`);
+                            if (!json) {
+                                this.pushError(`Brak danych w module ${name}`);
                                 return [];
                             }
 
@@ -469,9 +472,7 @@
 
                             return [];
                         } catch(e) {
-                            if (!this.error.includes(`Błąd wyświetlania modułu ${name}`)) {
-                                this.error.push(`Błąd wyświetlania modułu ${name}`);
-                            }
+                            this.pushError(`Błąd wyświetlania modułu ${name}`);
                             return [];
                         }
                     });
@@ -483,9 +484,7 @@
                     this.startRotation();
 
                 } catch(e) {
-                    if (!this.error.push('Błąd działania modułu rotacji')) {
-                        this.error.push('Błąd działania modułu rotacji');
-                    }
+                    this.pushError('Błąd działania modułu rotacji');
                     this.loading = false;
                 }
                 setTimeout(() => this.load(), 40000);


### PR DESCRIPTION
### Motivation
- The rotator previously mixed single-string assignments and array pushes for `error`, causing inconsistent types and fragile logic.
- Duplicate-checking used the unreliable pattern `if (!this.error.push(...))`, so deduplicated insertion should be explicit.

### Description
- Keep `error` as a `string[]` and add a `pushError(msg)` helper that performs `if (!this.error.includes(msg)) this.error.push(msg);`.
- Replace direct assignments like `this.error = '...'` with calls to `pushError(...)` throughout `multiModuleRotator()` and remove the `if (!this.error.push(...))` pattern.
- Change the error rendering template to render only when `error.length` is truthy and iterate over `error` as `(message, index) in error` with a key based on the message.
- All changes are limited to `src/Presentation/View/templates/pages/display.twig` in the `multiModuleRotator()` section and its associated error template.

### Testing
- Ran `rg` searches to verify old patterns were removed and new usages (`pushError`, `x-if="error.length"`, `x-for="(message, index) in error"`) exist, and the searches succeeded.
- Inspected the modified file with `sed`/`nl` to confirm the updated function and template, which succeeded.
- Verified repository status with `git status --short` and committed the change, and the commit command succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a118cd848321b02e854bd708a8cf)