### PR TITLE
Dodaj AGENTS.md i zaktualizuj dokumentację Display/Index/Panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+Instrukcje dla agentów AI pracujących w repozytorium **DoDomuDojade**.
+
+## Zakres
+Ten plik obowiązuje dla całego repozytorium (katalog root i wszystkie podkatalogi).
+
+## Cel zmian
+- Priorytetem jest utrzymanie spójności między kodem i dokumentacją (`README.md`, `resources/docs/*.md`).
+- Przy zmianach tras HTTP, middleware, endpointów API, komend CLI lub zmiennych `.env` **zawsze** zaktualizuj dokumentację.
+
+## Szybki workflow
+1. Zlokalizuj źródło prawdy w kodzie:
+   - routing: `public/index.php`
+   - składanie zależności: `src/Infrastructure/Container.php` oraz `src/Infrastructure/Container/Providers/`
+   - komendy CLI: `src/Console/CommandRegistry.php`, `src/Console/Commands/`
+   - konfiguracja runtime: `src/Infrastructure/Configuration/Config.php`
+   - schemat DB: `schema/schema.sql` + `schema/migrations/*.sql`
+2. Wprowadź minimalne, precyzyjne zmiany.
+3. Uruchom adekwatne sprawdzenia (minimum: diff + test/lint jeśli dotyczy).
+4. Zrób commit z jasnym komunikatem.
+
+## Konwencje dokumentacji
+- Pisz po polsku (zgodnie z aktualną dokumentacją projektu), techniczne nazwy i ścieżki zostawiaj po angielsku.
+- Unikaj opisów „jak powinno być”; opisuj to, **jak jest w kodzie teraz**.
+- Jeśli endpoint wymaga autoryzacji, dopisz to wprost.
+- Jeśli endpoint/feature może zwrócić `null` albo fallback — opisz to jawnie.
+
+## Konwencje zmian kodu
+- Nie dodawaj zbędnych refaktorów przy zadaniach stricte dokumentacyjnych.
+- Zachowuj istniejący styl i nazewnictwo.
+- Nie dodawaj nowych zależności bez wyraźnej potrzeby.
+
+## Kontrole jakości (dobierz do zakresu)
+- Testy: `vendor/bin/phpunit`
+- Analiza statyczna: `vendor/bin/phpstan analyse`
+- Lokalny podgląd docs: `mkdocs serve`
+
+Jeśli nie możesz uruchomić któregoś polecenia (np. brak zależności), odnotuj to w podsumowaniu.

--- a/resources/docs/display.md
+++ b/resources/docs/display.md
@@ -15,7 +15,8 @@ Podstrona `display` stanowi główną funkcjonalność aplikacji. To od niej zac
 | `/display/quote`             | GET    | JSON | Cytat dnia             | No   |
 | `/display/word`              | GET    | JSON | Słowo dnia             | No   |
 
-> Wszystkie endpoint-y Display zwracają spójny format z polem `is_active`, które mówi, czy dany moduł jest obecnie włączony
+> Wszystkie endpoint-y Display zwracają pole `is_active`, które mówi, czy dany moduł jest obecnie włączony.
+> Gdy moduł jest wyłączony lub nie ma danych, pole z payloadem (`departures`, `announcements`, `weather`, `countdown`, `events`, `quote`, `word`) może mieć wartość `null`.
 
 ---
 

--- a/resources/docs/index.md
+++ b/resources/docs/index.md
@@ -166,3 +166,21 @@ Oznacza to, że:
 
 ---
 **Masz pytania?** Otwórz [Issue](https://github.com/SLOths4/DoDomuDojade/issues) lub skontaktuj się z nami na [sloths4@spolecznaczworka.pl](mailto:sloths4@spolecznaczworka.pl).
+
+## Przewodnik dla maintainerów
+
+Najważniejsze miejsca w kodzie, które warto znać przy utrzymaniu projektu:
+
+- **Routing HTTP**: `public/index.php` (pełna lista tras + middleware per trasa).
+- **Kontener DI**: `src/Infrastructure/Container.php` oraz `src/Infrastructure/Container/Providers/`.
+- **Use case-y aplikacyjne**: `src/Application/`.
+- **Widoki Twig**: `src/Presentation/View/templates/`.
+- **Komendy CLI**: `src/Console/CommandRegistry.php` i `src/Console/Commands/`.
+- **Konfiguracja i walidacja ENV**: `src/Infrastructure/Configuration/Config.php`.
+
+### Checklista przed mergem
+
+1. Czy dokumentacja endpointów zgadza się z `public/index.php`?
+2. Czy zmiany w konfiguracji/env są odnotowane w README/docs?
+3. Czy zmiany w DB mają migrację i aktualny opis?
+4. Czy uruchomiono testy/lint adekwatne do zakresu zmian?

--- a/resources/docs/panel.md
+++ b/resources/docs/panel.md
@@ -130,7 +130,7 @@ Wyświetla stronę zarządzania modułami.
 
 ## Dependency Injection (Kontener)
 
-Instancja `PanelController` jest konfigurowana w `bootstrap/bootstrap.php`:
+Instancja `PanelController` jest konfigurowana przez providery kontenera w `src/Infrastructure/Container/Providers/` i składana w `src/Infrastructure/Container.php`:
 
 ```php
 $container->set(PanelController::class, fn(Container $c) => new PanelController(
@@ -179,8 +179,12 @@ Mapowanie nazw szablonów w enum `TemplateNames` (w `src/Presentation/View/Templ
 Poniższe endpoint-y API pracują z danymi wyświetlanymi w panelu:
 
 ### Użytkownicy
+- `GET /api/user` — pobierz wszystkich użytkowników
 - `POST /api/user` — dodaj użytkownika
+- `PATCH /api/user/{id}` — edytuj użytkownika
 - `DELETE /api/user/{id}` — usuń użytkownika
+- `POST /api/user/self/change-password` — zmień własne hasło
+- `POST /api/user/{id}/change-password` — zmień hasło wskazanego użytkownika
 
 ### Ogłoszenia
 - `POST /api/announcement` — dodaj ogłoszenie
@@ -192,6 +196,7 @@ Poniższe endpoint-y API pracują z danymi wyświetlanymi w panelu:
 - `POST /api/announcement/{id}/reject` — odrzuć ogłoszenie
 
 ### Liczniki
+- `GET /api/countdowns` — pobierz wszystkie liczniki
 - `POST /api/countdown` — dodaj licznik
 - `PATCH /api/countdown/{id}` — edytuj licznik
 - `DELETE /api/countdown/{id}` — usuń licznik
@@ -199,3 +204,10 @@ Poniższe endpoint-y API pracują z danymi wyświetlanymi w panelu:
 ### Moduły
 - `PATCH /api/module/{id}` — edytuj moduł
 - `POST /api/module/{id}/toggle` — włącz/wyłącz moduł
+
+## Dodatkowe trasy związane z panelem
+
+- `GET /panel/profile` oraz `GET /profile` — widok profilu użytkownika.
+- `GET /change-password` — formularz zmiany hasła (wymaga zalogowania).
+- `POST /api/authenticate` — logowanie użytkownika.
+


### PR DESCRIPTION
### Motivation
- Dostarczyć jasne instrukcje dla agentów AI pracujących w repozytorium oraz ujednolicić zasady wprowadzania zmian i kontroli jakości.  
- Wyjaśnić zachowanie endpointów Display w sytuacjach braku danych oraz doprecyzować miejsca odpowiedzialne za routing, DI i komendy CLI dla maintainerów.  

### Description
- Dodano nowy plik `AGENTS.md` z zakresem obowiązywania, szybkim workflow, konwencjami dokumentacji i kodu oraz polecanymi komendami QA.  
- Zmieniono `resources/docs/display.md`, aby doprecyzować, że każdy endpoint Display zwraca pole `is_active` oraz że pola z payloadem mogą być `null` gdy moduł jest wyłączony lub brak danych.  
- Zaktualizowano `resources/docs/index.md`, dodając przewodnik dla maintainerów z listą kluczowych plików i check-listą przed mergem.  
- Zmieniono `resources/docs/panel.md`, aby opisać, że `PanelController` jest konfigurowany przez providery kontenera w `src/Infrastructure/Container/Providers/`, zaktualizowano listę powiązanych endpointów API oraz dodano dodatkowe trasy związane z panelem.  

### Testing
- Nie uruchomiono automatycznych testów w ramach tej zmiany; zalecane polecenia do lokalnej weryfikacji to `vendor/bin/phpunit`, `vendor/bin/phpstan analyse` oraz `mkdocs serve`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016addc4f48321a820f4a4e79573a8)